### PR TITLE
v2.15.1.0

### DIFF
--- a/Infrastructure/Configuration.cpp
+++ b/Infrastructure/Configuration.cpp
@@ -94,7 +94,7 @@ cfg_var_modern::cfg_int
     CfgNukePanning(CfgNukePanningGUID, DefaultNukePanning);
 
 cfg_var_modern::cfg_float   CfgBASSMIDIVolume           ({ 0x143e8051, 0xa42b, 0x4225, {0xb9, 0xd2, 0x79, 0xf1, 0x43, 0x1e, 0x70, 0x16 } }, DefaultBASSMIDIVolume);
-cfg_var_modern::cfg_int     CfgBASSMIDIInterpolationMode({ 0xf9ddd2c0, 0xd8fd, 0x442f, { 0x9e, 0x49, 0xd9, 0x1, 0xb5, 0x1d, 0x6d, 0x38 } }, DefaultBASSMIDIInterpolationMode);
+cfg_var_modern::cfg_int     CfgBASSMIDIResamplingMode({ 0xf9ddd2c0, 0xd8fd, 0x442f, { 0x9e, 0x49, 0xd9, 0x1, 0xb5, 0x1d, 0x6d, 0x38 } }, DefaultBASSMIDIResamplingMode);
 
 #ifdef DXISUPPORT
 static const GUID default_cfg_dxi_plugin = { 0, 0, 0, { 0, 0, 0, 0, 0, 0, 0, 0 } };

--- a/Infrastructure/Configuration.h
+++ b/Infrastructure/Configuration.h
@@ -91,7 +91,7 @@ enum
 
     DefaultFluidSynthInterpolationMethod = FLUID_INTERP_DEFAULT,
 
-    DefaultBASSMIDIInterpolationMode = 1,
+    DefaultBASSMIDIResamplingMode = 1,
 
     DefaultGMSet = 0,
 
@@ -131,7 +131,7 @@ extern cfg_var_modern::cfg_int
 
     CfgFluidSynthInterpolationMode,
 
-    CfgBASSMIDIInterpolationMode,
+    CfgBASSMIDIResamplingMode,
 
     CfgADLBank,
     CfgADLChipCount,

--- a/Infrastructure/InputDecoder.h
+++ b/Infrastructure/InputDecoder.h
@@ -88,7 +88,7 @@ public:
         _FluidSynthInterpolationMethod((uint32_t) CfgFluidSynthInterpolationMode),
 
         _BASSMIDIVolume((float) CfgBASSMIDIVolume),
-        _BASSMIDIInterpolationMode((uint32_t) CfgBASSMIDIInterpolationMode)
+        _BASSMIDIInterpolationMode((uint32_t) CfgBASSMIDIResamplingMode)
     {
         _CleanFlags = (uint32_t) (CfgEmuDeMIDIExclusion ? midi_container_t::CleanFlagEMIDI : 0) |
                                  (CfgFilterInstruments ? midi_container_t::CleanFlagInstruments : 0) |

--- a/Infrastructure/PreferencesRoot.cpp
+++ b/Infrastructure/PreferencesRoot.cpp
@@ -448,7 +448,7 @@ void PreferencesRootPage::apply()
         ::uSetDlgItemText(m_hWnd, IDC_BASSMIDI_VOLUME, pfc::format_float(CfgBASSMIDIVolume, 4, 2));
     }
     {
-        CfgBASSMIDIInterpolationMode = (t_int32) SendDlgItemMessage(IDC_RESAMPLING_MODE, CB_GETCURSEL);
+        CfgBASSMIDIResamplingMode = (t_int32) SendDlgItemMessage(IDC_RESAMPLING_MODE, CB_GETCURSEL);
     }
 
     // Munt
@@ -591,9 +591,9 @@ void PreferencesRootPage::reset()
 
     // BASS MIDI resampling mode and cache status
     {
-        SendDlgItemMessage(IDC_RESAMPLING_MODE, CB_SETCURSEL, DefaultBASSMIDIInterpolationMode);
-
         ::uSetDlgItemText(m_hWnd, IDC_BASSMIDI_VOLUME, pfc::format_float(DefaultBASSMIDIVolume, 4, 2));
+
+        SendDlgItemMessage(IDC_RESAMPLING_MODE, CB_SETCURSEL, DefaultBASSMIDIResamplingMode);
 
         const bool IsBASSMIDI = (PlayerType == PlayerType::BASSMIDI);
 
@@ -644,7 +644,6 @@ void PreferencesRootPage::reset()
         {
             IDC_ADL_BANK_TEXT, IDC_ADL_BANK,
             IDC_ADL_CHIPS_TEXT, IDC_ADL_CHIPS,
-            IDC_RESAMPLING_LBL, IDC_RESAMPLING_MODE,
             IDC_ADL_PANNING
         };
 
@@ -938,7 +937,7 @@ BOOL PreferencesRootPage::OnInitDialog(CWindow, LPARAM)
         w.AddString(L"8pt Sinc interpolation");
         w.AddString(L"16pt Sinc interpolation");
 
-        w.SetCurSel((int) CfgBASSMIDIInterpolationMode);
+        w.SetCurSel((int) CfgBASSMIDIResamplingMode);
 
         bool Enable = (PlayerType == PlayerType::BASSMIDI);
 
@@ -1221,7 +1220,6 @@ void PreferencesRootPage::OnPlayerTypeChange(UINT, int, CWindow w)
         {
             IDC_ADL_BANK_TEXT, IDC_ADL_BANK,
             IDC_ADL_CHIPS_TEXT, IDC_ADL_CHIPS,
-            IDC_RESAMPLING_LBL, IDC_RESAMPLING_MODE,
             IDC_ADL_PANNING
         };
 
@@ -1405,7 +1403,7 @@ bool PreferencesRootPage::HasChanged()
         if (std::abs(::_wtof(Text) - CfgBASSMIDIVolume) > 0.001)
             return true;
 
-        if (SendDlgItemMessage(IDC_RESAMPLING_MODE, CB_GETCURSEL) != CfgBASSMIDIInterpolationMode)
+        if (SendDlgItemMessage(IDC_RESAMPLING_MODE, CB_GETCURSEL) != CfgBASSMIDIResamplingMode)
             return true;
     }
     #pragma endregion

--- a/README.md
+++ b/README.md
@@ -113,6 +113,11 @@ To create the component first build the x86 configuration and next the x64 confi
 
 ## Change Log
 
+v2.15.1.0, 2024-09-18
+
+* Fixed: The selected player now only gets overriden to BASSMIDI/FluidSynth when an embedded or a soundfont is found with the same basename as the MIDI file.
+* Fixed: The BASS MIDI Resampling combo box was not always enabled correctly when switching player types.
+
 v2.15.0.0, 2024-09-14
 
 * New: Support for embedded DLS sound fonts in RMI files. Works only with the FluidSynth player.
@@ -365,6 +370,7 @@ v2.7.4, 2022-11-03, *"Scratchin' the itch"*
 #### RMI
 
 * [About RMIDI](https://github.com/spessasus/SpessaSynth/wiki/About-RMIDI)
+* [Official SF2 RMIDI Specification](https://github.com/spessasus/sf2-rmidi-specification)
 
 #### RPC (Recomposer)
 

--- a/foo_midi.rc
+++ b/foo_midi.rc
@@ -1,5 +1,5 @@
 
-/** $VER: foo_midi.rc (2024.08.14) **/
+/** $VER: foo_midi.rc (2024.09.18) **/
 
 #include "resource.h"
 
@@ -96,10 +96,10 @@ font 8, "Segoe UI", 400, 0, 1
 
     groupbox "BASS MIDI", IDC_STATIC, X_A50, Y_A50, W_A50, H_A50
         rtext           "Volume:",          IDC_BASSMIDI_VOLUME_LBL,X_A57, Y_A57 + 2, W_A57, H_A57
-        edittext                            IDC_BASSMIDI_VOLUME,    X_A58, Y_A58, W_A58, H_A58, ES_RIGHT | ES_AUTOHSCROLL | WS_TABSTOP
-        rtext       "Resampling:",          IDC_RESAMPLING_LBL,    X_A53, Y_A53 + 2, W_A53, H_A53
+        edittext                            IDC_BASSMIDI_VOLUME,    X_A58, Y_A58,     W_A58, H_A58, ES_RIGHT | ES_AUTOHSCROLL | WS_TABSTOP
+        rtext       "Resampling:",          IDC_RESAMPLING_LBL,     X_A53, Y_A53 + 2, W_A53, H_A53
         combobox                            IDC_RESAMPLING_MODE,    X_A54, Y_A54,     W_A54, H_A54, CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
-        rtext           "Cached:",          IDC_CACHED_LBL,        X_A55, Y_A55 + 2, W_A55, H_A55
+        rtext           "Cached:",          IDC_CACHED_LBL,         X_A55, Y_A55 + 2, W_A55, H_A55
         ltext                  "",          IDC_CACHED,             X_A56, Y_A56 + 2, W_A56, H_A56, WS_VISIBLE
 
     groupbox "Munt", IDC_STATIC, X_A60, Y_A60, W_A60, H_A60

--- a/resource.h
+++ b/resource.h
@@ -1,5 +1,5 @@
 
-/** $VER: Resource.h (2024.09.14) P. Stuer **/
+/** $VER: Resource.h (2024.09.18) P. Stuer **/
 
 #pragma once
 
@@ -26,7 +26,7 @@
 
 #define NUM_FILE_MAJOR          2
 #define NUM_FILE_MINOR          15
-#define NUM_FILE_PATCH          0
+#define NUM_FILE_PATCH          1
 #define NUM_FILE_PRERELEASE     0
 
 #define STR_FILE_NAME           TEXT(STR_COMPONENT_FILENAME)
@@ -35,7 +35,7 @@
 
 #define NUM_PRODUCT_MAJOR       2
 #define NUM_PRODUCT_MINOR       15
-#define NUM_PRODUCT_PATCH       0
+#define NUM_PRODUCT_PATCH       1
 #define NUM_PRODUCT_PRERELEASE  0
 
 #define STR_PRODUCT_NAME        STR_COMPANY_NAME TEXT(" ") STR_INTERNAL_NAME


### PR DESCRIPTION
* Fixed: The selected player now only gets overriden to BASSMIDI/FluidSynth when an embedded or a soundfont is found with the same basename as the MIDI file.
* Fixed: The BASS MIDI Resampling combo box was not always enabled correctly when switching player types.