### PR TITLE
Restore config when using XG VSTi

### DIFF
--- a/Infrastructure/InputDecoder.cpp
+++ b/Infrastructure/InputDecoder.cpp
@@ -1,5 +1,5 @@
  
-/** $VER: InputDecoder.cpp (2025.08.01) **/
+/** $VER: InputDecoder.cpp (2025.08.17) **/
 
 #include "pch.h"
 
@@ -1049,9 +1049,9 @@ void InputDecoder::InitializeFade() noexcept
 /// <summary>
 /// Overrides the selected player depending on the metadata and some configuration settings.
 /// </summary>
-void InputDecoder::OverridePlayerSelection(preset_t & Preset, size_t subSongIndex, abort_callback & abortHandler) noexcept
+void InputDecoder::OverridePlayerSelection(preset_t & preset, size_t subSongIndex, abort_callback & abortHandler) noexcept
 {
-    _PlayerType = Preset._PlayerType;
+    _PlayerType = preset._PlayerType;
     _IsPlayerTypeOverriden = false;
 
     // Should the player be overriden by the metadata?
@@ -1078,12 +1078,26 @@ void InputDecoder::OverridePlayerSelection(preset_t & Preset, size_t subSongInde
     {
         pfc::string FilePath = CfgVSTiXGPlugInFilePath;
 
-        if (!FilePath.isEmpty())
-        {
-            _PlayerType = PlayerType::VSTi;
-            _IsPlayerTypeOverriden = true;
+        if (FilePath.isEmpty())
+            return;
 
-            Preset._PlugInFilePath = FilePath;
+        try
+        {
+            auto Player = new VSTi::Player;
+
+            if (Player->LoadVST((const char8_t *) FilePath.c_str()))
+            {
+                _PlayerType = PlayerType::VSTi;
+                _IsPlayerTypeOverriden = true;
+
+                preset._PlugInFilePath = FilePath;
+                preset._VSTiConfig = CfgVSTiConfig[Player->Id];
+
+                delete Player;
+            }
+        }
+        catch (...)
+        {
         }
     }
 }

--- a/Infrastructure/Preferences.cpp
+++ b/Infrastructure/Preferences.cpp
@@ -761,7 +761,7 @@ void RootDialog::OnButtonConfig(UINT, int, CWindow)
                 if (_VSTiHost.Config.size() != 0)
                     Player.SetChunk(_VSTiHost.Config.data(), _VSTiHost.Config.size());
 
-                Player.DisplayEditorModal();
+                Player.OpenEditor();
 
                 Player.GetChunk(_VSTiHost.Config);
             }

--- a/Players/SCPlayer.cpp
+++ b/Players/SCPlayer.cpp
@@ -490,7 +490,7 @@ static void ProcessPendingMessages()
 /// <summary>
 /// Creates a unique pipe name.
 /// </summary>
-bool SCPlayer::CreatePipeName(pfc::string_base & pipeName)
+bool SCPlayer::CreatePipeName(pfc::string_base & pipeName) noexcept
 {
     GUID guid;
 

--- a/Players/SCPlayer.h
+++ b/Players/SCPlayer.h
@@ -38,7 +38,7 @@ private:
     void StopHost(uint32_t port) noexcept;
     bool IsHostRunning(uint32_t port) noexcept;
 
-    static bool CreatePipeName(pfc::string_base & pipeName);
+    static bool CreatePipeName(pfc::string_base & pipeName) noexcept;
 
     uint32_t ReadCode(uint32_t port) noexcept;
 

--- a/Players/VSTiPlayer.h
+++ b/Players/VSTiPlayer.h
@@ -26,7 +26,7 @@ public:
 
     // Editor
     bool HasEditor();
-    void DisplayEditorModal();
+    void OpenEditor();
 
     // Setup
     virtual uint32_t GetAudioChannelCount() const noexcept override { return _ChannelCount; }

--- a/README.md
+++ b/README.md
@@ -95,10 +95,9 @@ To create the component first build the x64 configuration and next the x86 confi
 
 ## Change Log
 
-v3.1.1.0, 2025-08-15
+v3.1.2.0, 2025-08-17
 
-- Fixed: Under some conditions the BASSMIDI volume of a soundfont was set to 0.
-- Fixed: Some Unicode conversions failed when looking for extra soundfonts. See [STL issue 5093](https://github.com/microsoft/STL/issues/5093). Thanks to [MagikalUnicorn](https://github.com/MagikalUnicorn) for pointing it out.
+- New: The VSTi that is used when the [Use VSTi with XG](docs/README.md) is enabled loads its saved configuration before playback starts.
 
 You can read the full history [here](docs/History.md).
 

--- a/docs/History.md
+++ b/docs/History.md
@@ -1,6 +1,11 @@
 
 # foo_midi History
 
+v3.1.1.0, 2025-08-15
+
+- Fixed: Under some conditions the BASSMIDI volume of a soundfont was set to 0.
+- Fixed: Some Unicode conversions failed when looking for extra soundfonts. See [STL issue 5093](https://github.com/microsoft/STL/issues/5093). Thanks to [MagikalUnicorn](https://github.com/MagikalUnicorn) for pointing it out.
+
 v3.1.0.0, 2025-08-05
 
 - New: Added SFList support to the FluidSynth player. Due to limitations of the current FluidSynth API only the `fileName` property is used.

--- a/pch.h
+++ b/pch.h
@@ -1,5 +1,5 @@
 
-/** $VER: pch.h (2025.07.09) P. Stuer **/
+/** $VER: pch.h (2025.08.16) P. Stuer **/
 
 #pragma once
 
@@ -42,3 +42,12 @@ namespace fs = std::filesystem;
 EXTERN_C IMAGE_DOS_HEADER __ImageBase;
 #define THIS_HINSTANCE ((HINSTANCE) &__ImageBase)
 #endif
+
+template <class T> void SafeDelete(T& x) noexcept
+{
+    if (x)
+    {
+        delete[] x;
+        x = nullptr;
+    }
+}

--- a/resource.h
+++ b/resource.h
@@ -1,5 +1,5 @@
 
-/** $VER: Resource.h (2025.08.15) P. Stuer **/
+/** $VER: Resource.h (2025.08.17) P. Stuer **/
 
 #pragma once
 
@@ -27,7 +27,7 @@
 
 #define NUM_FILE_MAJOR              3
 #define NUM_FILE_MINOR              1
-#define NUM_FILE_PATCH              1
+#define NUM_FILE_PATCH              2
 #define NUM_FILE_PRERELEASE         0
 
 #define STR_FILE_NAME               TEXT(STR_COMPONENT_FILENAME)
@@ -36,7 +36,7 @@
 
 #define NUM_PRODUCT_MAJOR           3
 #define NUM_PRODUCT_MINOR           1
-#define NUM_PRODUCT_PATCH           1
+#define NUM_PRODUCT_PATCH           2
 #define NUM_PRODUCT_PRERELEASE      0
 
 #define STR_PRODUCT_NAME            STR_COMPANY_NAME TEXT(" ") STR_INTERNAL_NAME


### PR DESCRIPTION
- New: The VSTi that is used when the [Use VSTi with XG](docs/README.md) is enabled loads its saved configuration before playback starts.