### PR TITLE
Fix visualizer feedback during decode and adopt sample rate interface

### DIFF
--- a/GUI/API.h
+++ b/GUI/API.h
@@ -11,45 +11,59 @@
 
 #pragma region IKeyboard
 
-const uint32_t InterfaceVersion = 1;
+constexpr uint32_t InterfaceVersion = 1;
 
 class NOVTABLE IMusicKeyboard : public service_base
 {
 public:
-    /*
-        * \brief .
-        */
-    [[nodiscard]] virtual void Initialize(uint32_t version) = 0;
-    /*
-        * \brief Processes a MIDI message.
-        */
-    [[nodiscard]] virtual void ProcessMessage(uint32_t, uint32_t) = 0;
-    /*
-        * \brief Set the position of the first sample of the current chunk.
-        */
-    [[nodiscard]] virtual void SetPosition(uint32_t) = 0;
+    /**
+     * \brief Registers the calling producer and negotiates the interface version. Pass `InterfaceVersion`.
+     */
+    virtual void Initialize(uint32_t interfaceVersion) = 0;
+    /**
+     * \brief Delivers a MIDI message from the producer to the visualizer.
+     */
+    virtual void ProcessMessage(uint32_t message, uint32_t timestamp) = 0;
+    /**
+     * \brief Reports the sample index of the first sample of the producer's current chunk.
+     */
+    virtual void SetPosition(uint32_t position) = 0;
 
     FB2K_MAKE_SERVICE_INTERFACE(IMusicKeyboard, service_base);
 };
 
 DECLARE_CLASS_GUID(IMusicKeyboard, 0x527da15c, 0x5125, 0x4ba3, 0x99, 0x5d, 0xb8, 0x22, 0x98, 0x08, 0x41, 0x50);
 
+class NOVTABLE IMusicKeyboard_v2 : public IMusicKeyboard
+{
+public:
+    /**
+     * \brief Reports the sample index of the first sample of the producer's current chunk and the sample rate (Hz) needed to convert it to time.
+     *        Supersedes `SetPosition()`, which does not carry the sample rate.
+     */
+    virtual void SetTimelinePosition(uint32_t position, uint32_t sampleRate) = 0;
+
+    FB2K_MAKE_SERVICE_INTERFACE(IMusicKeyboard_v2, IMusicKeyboard);
+};
+
+DECLARE_CLASS_GUID(IMusicKeyboard_v2, 0x8bdf606d, 0xd3cf, 0x4442, 0xa0, 0x96, 0xeb, 0xb4, 0xe4, 0x59, 0x24, 0x7d);
+
 #pragma endregion
 
 #pragma region IAPI
 
-    class NOVTABLE IAPI : public service_base
-    {
-    public:
-        /*
-         * \brief Gets a MusicKeyboard object.
-         */
-        virtual IMusicKeyboard::ptr GetMusicKeyboard() const = 0;
+class NOVTABLE IAPI : public service_base
+{
+public:
+    /**
+     * \brief Gets a `MusicKeyboard` object.
+     */
+    virtual IMusicKeyboard::ptr GetMusicKeyboard() const = 0;
 
-        FB2K_MAKE_SERVICE_INTERFACE_ENTRYPOINT(IAPI)
-    };
+    FB2K_MAKE_SERVICE_INTERFACE_ENTRYPOINT(IAPI)
+};
 
-    DECLARE_CLASS_GUID(IAPI, 0x32166e94, 0xdb9f, 0x4a63, 0xa9, 0x37, 0x85, 0x36, 0xb2, 0x06, 0x51, 0x70);
+DECLARE_CLASS_GUID(IAPI, 0x32166e94, 0xdb9f, 0x4a63, 0xa9, 0x37, 0x85, 0x36, 0xb2, 0x06, 0x51, 0x70);
 
 #pragma endregion
 

--- a/Infrastructure/InputDecoder.cpp
+++ b/Infrastructure/InputDecoder.cpp
@@ -682,6 +682,8 @@ void InputDecoder::decode_initialize(unsigned subSongIndex, unsigned flags, abor
         }
     }
 
+    _Player->EnableVisualization((_DecoderFlags & input_flag_playback) != 0);
+
     _IsEndOfContainer = false;
 }
 

--- a/Players/Player.cpp
+++ b/Players/Player.cpp
@@ -29,18 +29,6 @@ player_t::player_t() noexcept
     _FileFormat = midi::FileFormat::Unknown;
 
     _IsStarted = false;
-
-#ifdef HAVE_FOO_VIS_MIDI
-    {
-        IAPI::ptr api;
-
-        if (fb2k::std_api_try_get(api))
-            _MusicKeyboard = api->GetMusicKeyboard();
-
-        if (_MusicKeyboard.is_valid())
-            _MusicKeyboard->Initialize(InterfaceVersion);
-    }
-#endif
 }
 
 /// <summary>
@@ -442,7 +430,12 @@ uint32_t player_t::Play(audio_sample * frameData, uint32_t frameCount) noexcept
 
 #ifdef HAVE_FOO_VIS_MIDI
     if (_MusicKeyboard.is_valid())
-        _MusicKeyboard->SetPosition(OldFrameIndex);
+    {
+        if (_MusicKeyboardV2.is_valid())
+            _MusicKeyboardV2->SetTimelinePosition(OldFrameIndex, _SampleRate);
+        else
+            _MusicKeyboard->SetPosition(OldFrameIndex);
+    }
 #endif
 
     return FrameIndex;
@@ -608,6 +601,30 @@ void player_t::Seek(uint32_t newFrameIndex)
             delete[] FrameData;
         }
     }
+}
+
+/// <summary>
+/// Acquires the keyboard visualizer only for playback. Analysis/scan decodes must not drive it.
+/// </summary>
+void player_t::EnableVisualization(bool enabled) noexcept
+{
+#ifdef HAVE_FOO_VIS_MIDI
+    if (!enabled)
+        return;
+
+    IAPI::ptr api;
+
+    if (fb2k::std_api_try_get(api))
+        _MusicKeyboard = api->GetMusicKeyboard();
+
+    if (_MusicKeyboard.is_valid())
+    {
+        _MusicKeyboard->Initialize(InterfaceVersion);
+        _MusicKeyboard->service_query_t(_MusicKeyboardV2);
+    }
+#else
+    UNREFERENCED_PARAMETER(enabled);
+#endif
 }
 
 /// <summary>

--- a/Players/Player.h
+++ b/Players/Player.h
@@ -34,6 +34,8 @@ public:
     uint32_t Play(audio_sample * samplesData, uint32_t samplesSize) noexcept;
     void Seek(uint32_t seekTime);
 
+    void EnableVisualization(bool enabled) noexcept;
+
     uint32_t GetSampleRate() const noexcept { return _SampleRate; };
     void SetSampleRate(uint32_t sampleRate);
 
@@ -112,6 +114,7 @@ private:
 
 #ifdef HAVE_FOO_VIS_MIDI
     IMusicKeyboard::ptr _MusicKeyboard;
+    IMusicKeyboard_v2::ptr _MusicKeyboardV2;
 #endif
 };
 


### PR DESCRIPTION
Only forward MIDI messages to the foo_vis_midi visualizer during actual playback. Previously, decode-only passes (e.g., seeking, analysis, or non-playback decoding) also drove the keyboard, causing spurious visual activity with no audible output.

Switch to `IMusicKeyboard_v2` and report the timeline position via `SetTimelinePosition(position, sampleRate)` instead of `SetPosition(position)`. Supplying the sample rate lets the visualizer convert sample indices to time accurately across streams with differing rates.